### PR TITLE
Set documentSelector scheme to "file" only

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,12 +45,12 @@ export async function activate(context: vscode.ExtensionContext) {
     documentSelector: [
       { 
         language: "helm",
-        scheme: "file"
+        scheme: "file",
       },
       {
         language: "yaml",
         pattern: "**/values*.yaml",
-        scheme: "file"
+        scheme: "file",
       },
     ],
     synchronize: {},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,10 +43,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
-      { language: "helm" },
+      { 
+        language: "helm",
+        scheme: "file"
+      },
       {
         language: "yaml",
         pattern: "**/values*.yaml",
+        scheme: "file"
       },
     ],
     synchronize: {},


### PR DESCRIPTION
helm-ls crashes on git scheme (happens when viewing git diff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the extension to operate only on file-backed Helm and values YAML documents, preventing activation on untitled, in-memory, or virtual resources.
  * Reduces false positives and unexpected behavior, improving stability and accuracy of linting, completions, and diagnostics for supported files.
  * Enhances user experience by limiting features to appropriate contexts and avoiding unnecessary processing on unsupported documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->