### PR TITLE
feat: add visual highlighting for unused values in YAML files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import {
 } from "vscode-languageclient/node";
 import { getHelmLsExecutable } from "./util/executable";
 import { getYamllsPath } from "./util/yamlls-path";
+import * as unusedValuesDecorator from "./util/unusedValuesDecorator";
 
 let client: LanguageClient;
 
@@ -79,10 +80,13 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   client.start();
+
+  unusedValuesDecorator.activate(context);
 }
 
 export function deactivate(): Thenable<void> | undefined {
   console.log("Deactivating helm-ls");
+  unusedValuesDecorator.deactivate();
   if (!client) {
     return undefined;
   }

--- a/src/util/unusedValuesDecorator.ts
+++ b/src/util/unusedValuesDecorator.ts
@@ -1,0 +1,94 @@
+import * as vscode from 'vscode';
+
+let decorationType: vscode.TextEditorDecorationType;
+
+function getDecorationOptions(): vscode.DecorationRenderOptions {
+    const isLightTheme = vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Light;
+
+    const color = isLightTheme
+        ? 'rgba(180, 141, 0, 0.33)'
+        : 'rgba(253, 251, 251, 0.43)';
+
+    return {
+        textDecoration: `underline wavy ${color}`,
+        overviewRulerColor: color,
+        overviewRulerLane: vscode.OverviewRulerLane.Right
+    };
+}
+
+export function activate(context: vscode.ExtensionContext) {
+    decorationType = vscode.window.createTextEditorDecorationType(getDecorationOptions());
+
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveColorTheme(() => {
+            decorationType.dispose();
+            decorationType = vscode.window.createTextEditorDecorationType(getDecorationOptions());
+            refreshAllEditors();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.languages.onDidChangeDiagnostics((event) => {
+            event.uris.forEach(uri => {
+                const editor = vscode.window.visibleTextEditors.find(e => e.document.uri.toString() === uri.toString());
+                if (editor) {
+                    updateDecorations(editor);
+                }
+            });
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeTextDocument((event) => {
+            const editor = vscode.window.visibleTextEditors.find(e => e.document === event.document);
+            if (editor && isValuesFile(editor.document.fileName)) {
+                updateDecorations(editor);
+            }
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor((editor) => {
+            if (editor) {
+                updateDecorations(editor);
+            }
+        })
+    );
+
+    if (vscode.window.activeTextEditor) {
+        updateDecorations(vscode.window.activeTextEditor);
+    }
+}
+
+function isValuesFile(fileName: string): boolean {
+    return fileName.includes('values.yaml') || fileName.includes('values.yml');
+}
+
+function refreshAllEditors() {
+    vscode.window.visibleTextEditors.forEach(editor => {
+        updateDecorations(editor);
+    });
+}
+
+function updateDecorations(editor: vscode.TextEditor) {
+    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+
+    const unusedValueDecorations: vscode.DecorationOptions[] = diagnostics
+        .filter(diagnostic =>
+            // TODO: Remove empty source check after helm-ls commit 780fcd0 is merged
+            (diagnostic.source === 'helm-ls unused values' || diagnostic.source === '') &&
+            diagnostic.tags?.includes(vscode.DiagnosticTag.Unnecessary)
+        )
+        .map(diagnostic => ({
+            range: diagnostic.range,
+            hoverMessage: new vscode.MarkdownString(`⚠️ ${diagnostic.message}`)
+        }));
+
+    editor.setDecorations(decorationType, unusedValueDecorations);
+}
+
+export function deactivate() {
+    if (decorationType) {
+        decorationType.dispose();
+    }
+}


### PR DESCRIPTION
## Add Visual Highlighting for Unused Values in YAML Files
 
This PR adds visual highlighting for unused values in Helm values files, providing immediate feedback to users about
which values are not referenced in their templates.
 
### Features
 
• **Visual Indicators**: Unused values are highlighted with wavy underlines that adapt to light/dark themes
• **Real-time Updates**: Decorations update immediately as users type, not just when diagnostics change
• **LSP Integration**: Leverages helm-ls diagnostics with DiagnosticTagUnnecessary for accurate detection
• **Hover Information**: Shows helpful messages when hovering over unused values
• **Theme Support**: Uses appropriate colors for both light and dark VSCode themes
 
### Implementation
 
• Added unusedValuesDecorator.ts utility in src/util/
• Integrated with existing LSP client in main extension
• Listens for both diagnostic changes and text document changes for responsive UX
• Filters diagnostics by source (helm-ls unused values) and diagnostic tags
 
### Compatibility
 
Includes temporary compatibility with current helm-ls versions that send empty source strings. This will be cleaned
up once [helm-ls commit 780fcd0](https://github.com/mrjosh/helm-ls/commit/780fcd0c3633267ece074e12dfa1f0afad570ae9) is merged.
 
### Screenshots
 
<img width="366" height="273" alt="image" src="https://github.com/user-attachments/assets/d4cd757d-54dc-4fde-bc93-0d1ff13105cb" />

 
### Related Issues
 
Addresses the need for better visual feedback on unused Helm values, improving developer experience when working
with large values files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unused values in YAML files now display visual indicators with wavy underlines. Hover over highlighted areas for context. Indicators automatically adapt to your theme and update in real-time as you edit files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->